### PR TITLE
refactor(cmd)!: set simple output as default

### DIFF
--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -14,10 +14,10 @@ import (
 	"github.com/spf13/viper"
 )
 
-var simpleOutput bool
+var complexOutput bool
 
 func init() {
-	publishCmd.PersistentFlags().BoolVar(&simpleOutput, "simple", false, "use simplified output")
+	publishCmd.PersistentFlags().BoolVar(&complexOutput, "complex", false, "use complex output")
 	rootCmd.AddCommand(publishCmd)
 }
 
@@ -69,7 +69,7 @@ var publishCmd = &cobra.Command{
 		sections := text.SplitSections(parsedCommits)
 
 		releaseNotes := text.ReleaseNotes{
-			Simple: simpleOutput,
+			Complex: complexOutput,
 		}
 
 		content := releaseNotes.Generate(sections, dryRun)

--- a/internal/text/build_single_commit.go
+++ b/internal/text/build_single_commit.go
@@ -10,7 +10,7 @@ import (
 func (r *ReleaseNotes) buildSingleCommit(commit quoad.Commit, isLast, open bool) string {
 	builder := strings.Builder{}
 
-	if r.Simple || commit.Body == "" {
+	if !r.Complex || commit.Body == "" {
 		simpleCommitMessage := buildSimpleCommit(commit)
 		builder.WriteString(simpleCommitMessage)
 	} else {

--- a/internal/text/release_notes.go
+++ b/internal/text/release_notes.go
@@ -3,13 +3,13 @@ package text
 import (
 	"fmt"
 	"strings"
-	
+
 	"github.com/outillage/quoad"
 )
 
 // ReleaseNotes holds the required settings for generating ReleaseNotes
 type ReleaseNotes struct {
-	Simple bool
+	Complex bool
 }
 
 // Generate generates the output mentioned in the expected-output.md

--- a/internal/text/release_notes_test.go
+++ b/internal/text/release_notes_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestReleaseNotes(t *testing.T) {
-	notes := ReleaseNotes{}
+	notes := ReleaseNotes{Complex: true}
 	file, err := os.Open("../../expected-output.md")
 
 	assert.NoError(t, err)


### PR DESCRIPTION
BREAKING CHANGE: simple output is now the default output. Complex output is hidden under the --complex flag.

Switches Simple output as the default one.

Changes simple flag -> complex flag.