### PR TITLE
refactor(text): add - delimiter

### DIFF
--- a/expected-output-simple.md
+++ b/expected-output-simple.md
@@ -2,18 +2,18 @@ test heading
 
 ## :rocket: Features
 
-0000000 ci test
+- 0000000 ci test
 
 ## :bug: Bug fixes
 
-0000000 huge bug
+- 0000000 huge bug
 
 ## :wrench: Chores and Improvements
 
-0000000 testing
-0000000 this should end up in chores #12
+- 0000000 testing
+- 0000000 this should end up in chores #12
 
 ## :package: Other
 
-0000000 merge master in something
-0000000 random
+- 0000000 merge master in something
+- 0000000 random

--- a/expected-output.md
+++ b/expected-output.md
@@ -23,9 +23,9 @@ Body
 - Body
 
 </details>
-0000000 this should end up in chores #12
+- 0000000 this should end up in chores #12
 
 ## :package: Other
 
-0000000 merge master in something
-0000000 random
+- 0000000 merge master in something
+- 0000000 random

--- a/internal/text/build_single_commit.go
+++ b/internal/text/build_single_commit.go
@@ -27,6 +27,7 @@ func buildSimpleCommit(commit quoad.Commit) string {
 	builder := strings.Builder{}
 
 	// Short version of hash usable on Github
+	builder.WriteString("- ")
 	builder.WriteString(commit.Hash.String()[:7])
 	builder.WriteString(" ")
 	builder.WriteString(commit.Heading)

--- a/internal/text/release_notes_test.go
+++ b/internal/text/release_notes_test.go
@@ -63,7 +63,7 @@ func TestReleaseNotesSimple(t *testing.T) {
 
 func TestReleaseNotesWithMissingSections(t *testing.T) {
 	notes := ReleaseNotes{}
-	expected := "\n\n## :rocket: Features\n\n0000000 ci test\n\n"
+	expected := "\n\n## :rocket: Features\n\n- 0000000 ci test\n\n"
 
 	sections := map[string][]quoad.Commit{
 		"features": []quoad.Commit{quoad.Commit{Heading: "ci test"}},


### PR DESCRIPTION
Makes all simple outputs a list which makes markdown formatting easier.