### PR TITLE
fix(tests): rework publish to use GitRemoter interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/outillage/git/v2 v2.0.1
-	github.com/outillage/integrations v0.2.0
+	github.com/outillage/integrations v0.3.0
 	github.com/outillage/quoad v0.2.0
 	github.com/pelletier/go-toml v1.6.0 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/outillage/git/v2 v2.0.1 h1:spc5mZmSvB05Yjz119tpiDCFMQKlglEHDcSqzBA2Log=
 github.com/outillage/git/v2 v2.0.1/go.mod h1:c6L0qnmoC0TYDt9Cer+HziO77yzvrfNlPAEXBAH+HRM=
-github.com/outillage/integrations v0.2.0 h1:uI/7nO4FZP6+/L8eSdBaJwSe+hNDVbY+lxpw9vMmQlM=
-github.com/outillage/integrations v0.2.0/go.mod h1:8TUKHOdlQoUYul8EhwTiBR8b1q94HCtY1pGHWH505Gg=
+github.com/outillage/integrations v0.3.0 h1:HlYQpsuLEOfOZUCxUmR1Z3/N5GeeaLaNeLFasMrTHEI=
+github.com/outillage/integrations v0.3.0/go.mod h1:8TUKHOdlQoUYul8EhwTiBR8b1q94HCtY1pGHWH505Gg=
 github.com/outillage/quoad v0.2.0 h1:jAFYegH3ASd3YEQCVuviHMiWDFxQAOfl7ox4BSBPriY=
 github.com/outillage/quoad v0.2.0/go.mod h1:VdBGieQx7EtZDWn10L2fyW6ZT3uDstIhlTbPwDNL25o=
 github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtbSNq5BcowyYOWdKo=

--- a/internal/slack/gitremorter_mock_test.go
+++ b/internal/slack/gitremorter_mock_test.go
@@ -1,0 +1,17 @@
+package slack
+
+// MockRemote serves to mock the GitRemoter interface
+type MockRemote struct {
+}
+
+func (r MockRemote) Host() string {
+	return "example.com"
+}
+
+func (r MockRemote) Project() string {
+	return "some/thing"
+}
+
+func (r MockRemote) GetRemoteURL() string {
+	return "https://example.com/some/thing"
+}

--- a/internal/slack/publish.go
+++ b/internal/slack/publish.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
-	"github.com/outillage/integrations"
 	"github.com/outillage/quoad"
 )
 
@@ -23,7 +22,7 @@ func jsonMarshal(t interface{}) ([]byte, error) {
 }
 
 // Publish pushes the release notes to Slack via provided Webhook. https://api.slack.com/reference/messaging/payload
-func (s *Slack) Publish(commits map[string][]quoad.Commit, remote integrations.GitRemote) error {
+func (s *Slack) Publish(commits map[string][]quoad.Commit, remote GitRemoter) error {
 	releaseNotes := GenerateReleaseNotes(commits, remote)
 
 	client := http.Client{

--- a/internal/slack/publish_test.go
+++ b/internal/slack/publish_test.go
@@ -4,16 +4,13 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
-	"github.com/outillage/integrations"
 	"github.com/outillage/quoad"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestPublish(t *testing.T) {
-	os.Clearenv()
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		assert.Equal(t, "/webhook", req.URL.String())
 		assert.Equal(t, "application/json", req.Header["Content-Type"][0])
@@ -65,10 +62,7 @@ func TestPublish(t *testing.T) {
 		},
 	}
 
-	remote := integrations.GitRemote{
-		Host:    "example.com",
-		Project: "some/thing",
-	}
+	remote := MockRemote{}
 
 	err := slack.Publish(testData, remote)
 

--- a/internal/slack/release_notes_test.go
+++ b/internal/slack/release_notes_test.go
@@ -2,10 +2,8 @@ package slack
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
-	"github.com/outillage/integrations"
 	"github.com/outillage/quoad"
 	"github.com/stretchr/testify/assert"
 )
@@ -19,11 +17,7 @@ func ref(issue int) string {
 }
 
 func TestGenerateReleaseNotes(t *testing.T) {
-	os.Clearenv()
-	remote := integrations.GitRemote{
-		Host:    "example.com",
-		Project: "some/thing",
-	}
+	remote := MockRemote{}
 
 	testData := map[string][]quoad.Commit{
 		"features": []quoad.Commit{
@@ -166,5 +160,5 @@ func TestGenerateReleaseNotes(t *testing.T) {
 		},
 	})
 
-	assert.Equal(t, expectedOutput, GenerateReleaseNotes(testData, remote))
+	assert.ElementsMatch(t, expectedOutput.Blocks, GenerateReleaseNotes(testData, remote).Blocks)
 }

--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -4,3 +4,9 @@ package slack
 type Slack struct {
 	WebHookURL string
 }
+
+type GitRemoter interface {
+	GetRemoteURL() string
+	Host() string
+	Project() string
+}


### PR DESCRIPTION
- updates outillage/integrations to v0.3.0
- previous approach was causing issues in tests as it was also testing the logic inside outillage/integrations instead of testing just release notes
- integrations would get the env variables leading to failing tests